### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8
+  - conda create --yes -n test-env python=$PYTHON_VERSION nose
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
+  - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_dummy_types setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME development team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2-dummy-types nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_dummy_types/__init__.py
+++ b/q2_dummy_types/__init__.py
@@ -1,12 +1,15 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = "0.0.7.dev0"  # noqa
+import pkg_resources
+
+# Skip flake8 validation to avoid import cycle.
+__version__ = pkg_resources.get_distribution('q2-dummy-types').version  # noqa
 
 # Make the types defined in this plugin importable from the top-level package
 # so they can be easily imported by other plugins relying on these types.

--- a/q2_dummy_types/_int_sequence.py
+++ b/q2_dummy_types/_int_sequence.py
@@ -1,19 +1,19 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime.plugin
-import qiime.plugin.model as model
+import qiime2.plugin
+import qiime2.plugin.model as model
 
 from .plugin_setup import plugin
 
 # Define semantic types.
-IntSequence1 = qiime.plugin.SemanticType('IntSequence1')
-IntSequence2 = qiime.plugin.SemanticType('IntSequence2')
+IntSequence1 = qiime2.plugin.SemanticType('IntSequence1')
+IntSequence2 = qiime2.plugin.SemanticType('IntSequence2')
 
 # Register semantic types on the plugin.
 plugin.register_semantic_types(IntSequence1, IntSequence2)
@@ -42,6 +42,7 @@ class IntSequenceFormat(model.TextFileFormat):
                 except (TypeError, ValueError):
                     return False
             return True
+
 
 # Define a directory format. A directory format is a directory structure
 # composed of one or more files (nested directories are also supported). Each

--- a/q2_dummy_types/_mapping.py
+++ b/q2_dummy_types/_mapping.py
@@ -1,18 +1,18 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime.plugin
-import qiime.plugin.model as model
+import qiime2.plugin
+import qiime2.plugin.model as model
 
 from .plugin_setup import plugin
 
 # Define semantic types.
-Mapping = qiime.plugin.SemanticType('Mapping')
+Mapping = qiime2.plugin.SemanticType('Mapping')
 
 # Register semantic types on the plugin.
 plugin.register_semantic_types(Mapping)
@@ -41,6 +41,7 @@ class MappingFormat(model.TextFileFormat):
                 if len(cells) != 2:
                     return False
             return True
+
 
 # Define a directory format. A directory format is a directory structure
 # composed of one or more files (nested directories are also supported). Each

--- a/q2_dummy_types/plugin_setup.py
+++ b/q2_dummy_types/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,11 +8,11 @@
 
 import importlib
 
-import qiime.plugin
+import qiime2.plugin
 
 import q2_dummy_types
 
-plugin = qiime.plugin.Plugin(
+plugin = qiime2.plugin.Plugin(
     name='dummy-types',
     version=q2_dummy_types.__version__,
     website='https://github.com/qiime2/q2-dummy-types',
@@ -20,7 +20,7 @@ plugin = qiime.plugin.Plugin(
 )
 
 # It is important that any modules registering functionality onto the
-# `qiime.plugin.Plugin` object are imported so the registrations take place.
+# `qiime2.plugin.Plugin` object are imported so the registrations take place.
 # When the QIIME 2 framework discovers plugin objects, it only imports the
 # module where the plugin is defined, so any modules that register
 # functionality onto this object must also be imported. If registrations happen

--- a/q2_dummy_types/tests/__init__.py
+++ b/q2_dummy_types/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_dummy_types/tests/test_int_sequence.py
+++ b/q2_dummy_types/tests/test_int_sequence.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,8 +10,8 @@ import pkg_resources
 import unittest
 import uuid
 
-import qiime.core.archive as archive
-from qiime.sdk import Artifact
+import qiime2.core.archive as archive
+from qiime2.sdk import Artifact
 
 from q2_dummy_types import IntSequence1, IntSequence2
 

--- a/q2_dummy_types/tests/test_mapping.py
+++ b/q2_dummy_types/tests/test_mapping.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,8 +10,8 @@ import pkg_resources
 import unittest
 import uuid
 
-import qiime.core.archive as archive
-from qiime.sdk import Artifact
+import qiime2.core.archive as archive
+from qiime2.sdk import Artifact
 
 from q2_dummy_types import Mapping
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,22 +10,21 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-dummy-types",
-    # TODO stop duplicating version string
-    version="0.0.7.dev0",
+    version='2017.2.0.dev0',
+    license='BSD-3-Clause',
+    url='https://qiime2.org',
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6'],
+    install_requires=['qiime2 == 2017.2.*'],
     author="Jai Ram Rideout",
     author_email="jai.rideout@gmail.com",
     description="Dummy QIIME 2 types to serve as examples for plugin "
                 "developers.",
-    license='BSD-3-Clause',
-    url="https://github.com/qiime2/q2-dummy-types",
-    # Use the 'qiime.plugins' entry point to make this plugin discoverable by
+    # Use the 'qiime2.plugins' entry point to make this plugin discoverable by
     # the QIIME 2 framework. The path after the equals sign (=) is the full
-    # import path to a `qiime.plugin.Plugin` object. This object can be located
-    # anywhere within the package.
+    # import path to a `qiime2.plugin.Plugin` object. This object can be
+    # located anywhere within the package.
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-dummy-types=q2_dummy_types.plugin_setup:plugin']
     },
     package_data={


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0,
  2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in
setup.py's `install_requires` to obtain patch releases for a given train
release.

The new versioning scheme is PEP 440 compliant.